### PR TITLE
Variable `config.default_language` not found

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
         {% include "parts/me.html" %}
     </header>
     <main>
-        {% if lang != config.default_language %}
+        {% if lang != lang %}
         <blockquote>
         <b>INFO:</b> This is not the default language. There may be articles that are not translated. You can switch back to the default language <a href="/">here</a>.
         </blockquote>


### PR DESCRIPTION
According to this issue on [Zola](https://github.com/getzola/zola/issues/1442)