### PR TITLE
Add rel attribute to social media links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -45,7 +45,11 @@
             <div class="footer-social-media">
                 <a onclick="toggle_prefers_color()">Toggle Theme</a>
                 {% for social in config.extra.social_media %}
-                    <a href="{{ social.url | safe }}" target="_blank">{{ social.name }}</a>
+                    {% if social.rel %}
+                        <a href="{{ social.url | safe }}" rel="{{ social.rel }}" target="_blank">{{ social.name }}</a>
+                    {% else %}
+                        <a href="{{ social.url | safe }}" target="_blank">{{ social.name }}</a>
+                    {% endif %}
                 {% endfor %}
             </div>
         </footer>

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,14 +42,12 @@
         {% endblock content %}
         <footer>
             <hr text="&copy; Copyright {{ now() | date(format='%Y') }}" />
-            {% if config.extra.social_media and config.extra.social_media | length > 0 %}
             <div class="footer-social-media">
                 <a onclick="toggle_prefers_color()">Toggle Theme</a>
                 {% for social in config.extra.social_media %}
                     <a href="{{ social.url | safe }}" target="_blank">{{ social.name }}</a>
                 {% endfor %}
             </div>
-            {% endif %}
         </footer>
     </body>
 


### PR DESCRIPTION
Mastodon uses the `rel="me"` attribute on social media links to verify an account, this is a small patch that ensures that.

It aslo adds a small fix so that the Toggle Theme button is not hidden if there are no Social Media links.